### PR TITLE
Fixed

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -33,11 +33,6 @@ module.exports = {
   output: {
     filename: `${PATHS.assets}js/[name].[contenthash].js`,
     path: PATHS.dist,
-    /*
-      publicPath: '/' - relative path for dist folder (js,css etc)
-      publicPath: './' (dot before /) - absolute path for dist folder (js,css etc)
-    */
-    publicPath: '/'
   },
   optimization: {
     splitChunks: {
@@ -71,15 +66,16 @@ module.exports = {
       },
       {
         // Fonts
-        test: /\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
+        test: /(\.(woff(2)?|ttf|eot)(\?v=\d+\.\d+\.\d+)?$|font.*\.svg$)/,
         loader: 'file-loader',
         options: {
+          outputPath: 'assets/fonts',
           name: '[name].[ext]'
         }
       },
       {
         // images / icons
-        test: /\.(png|jpg|gif|svg)$/,
+        test: /(\.(png|jpg|gif)$|^((?!font).)*\.svg$)/,
         loader: 'file-loader',
         options: {
           name: '[name].[ext]'
@@ -140,23 +136,18 @@ module.exports = {
     // Vue loader
     new VueLoaderPlugin(),
     new MiniCssExtractPlugin({
-      filename: `${PATHS.assets}css/[name].[contenthash].css`
+      filename: `[name].[contenthash].css`
     }),
     new CopyWebpackPlugin({
       patterns: [
         // Images:
         {
-          from: `${PATHS.src}/${PATHS.assets}img`,
-          to: `${PATHS.assets}img`
-        },
-        // Fonts:
-        {
-          from: `${PATHS.src}/${PATHS.assets}fonts`,
-          to: `${PATHS.assets}fonts`
+          from: `./src/assets/img`,
+          to: `assets/img`
         },
         // Static (copy to '/'):
         {
-          from: `${PATHS.src}/static`,
+          from: `./src/static`,
           to: ''
         }
       ]

--- a/src/assets/scss/utils/fonts.scss
+++ b/src/assets/scss/utils/fonts.scss
@@ -16,29 +16,29 @@
   // Base Helvetica (example):
   @font-face {
     font-family: "Helvetica-Base";
-    src: url('/assets/fonts/Helvetica/Base/Helvetica-Base.eot'); // IE9 Compat Modes
-    src: url('/assets/fonts/Helvetica/Base/Helvetica-Base.eot?#iefix') format('embedded-opentype'), // IE6-IE8
-         url('/assets/fonts/Helvetica/Base/Helvetica-Base.woff') format('woff'), // Pretty Modern Browsers
-         url('/assets/fonts/Helvetica/Base/Helvetica-Base.ttf')  format('truetype'), // Safari, Android, iOS
-         url('/assets/fonts/Helvetica/Base/Helvetica-Base.svg') format('svg'); // Legacy iOS
+    src: url('/src/assets/fonts/Helvetica/Base/Helvetica-Base.eot'); // IE9 Compat Modes
+    src: url('/src/assets/fonts/Helvetica/Base/Helvetica-Base.eot?#iefix') format('embedded-opentype'), // IE6-IE8
+         url('/src/assets/fonts/Helvetica/Base/Helvetica-Base.woff') format('woff'), // Pretty Modern Browsers
+         url('/src/assets/fonts/Helvetica/Base/Helvetica-Base.ttf')  format('truetype'), // Safari, Android, iOS
+         url('/src/assets/fonts/Helvetica/Base/Helvetica-Base.svg') format('svg'); // Legacy iOS
   }
 */
 
 // 2. Example with mixin (example):
 
 /* NOTE:
-  1. do NOT use expansion (.woff, .svg etc) for path! Path will be '/assets/fonts/OpenSans/opensans;
+  1. do NOT use expansion (.woff, .svg etc) for path! Path will be '/src/assets/fonts/OpenSans/opensans;
   2, files required: `.woff, .woffs` (by default) OR `eot. .woff, .woffs, .svg, .ttf` if you use another mixin.
 */
 
 // Base OpenSans:
-// @include font-face("OpenSans", "/assets/fonts/OpenSans/opensans");
-// @include font-face("OpenSans", "/assets/fonts/OpenSans/opensanslight", 300);
-// @include font-face("OpenSans", "/assets/fonts/OpenSans/opensanssemibold", 600);
-// @include font-face("OpenSans", "/assets/fonts/OpenSans/opensansbold", bold);
+// @include font-face("OpenSans", "/src/assets/fonts/OpenSans/opensans");
+// @include font-face("OpenSans", "/src/assets/fonts/OpenSans/opensanslight", 300);
+// @include font-face("OpenSans", "/src/assets/fonts/OpenSans/opensanssemibold", 600);
+// @include font-face("OpenSans", "/src/assets/fonts/OpenSans/opensansbold", bold);
 
 // Italic OpenSans:
-// @include font-face("OpenSans", "/assets/fonts/OpenSans/opensansItalic", 400, italic);
-// @include font-face("OpenSans", "/assets/fonts/OpenSans/opensansLightItalic", 300, italic);
-// @include font-face("OpenSans", "/assets/fonts/OpenSans/opensansSemiBoldItalic", 600, italic);
-// @include font-face("OpenSans", "/assets/fonts/OpenSans/opensansBoldItalic", bold, italic);
+// @include font-face("OpenSans", "/src/assets/fonts/OpenSans/opensansItalic", 400, italic);
+// @include font-face("OpenSans", "/src/assets/fonts/OpenSans/opensansLightItalic", 300, italic);
+// @include font-face("OpenSans", "/src/assets/fonts/OpenSans/opensansSemiBoldItalic", 600, italic);
+// @include font-face("OpenSans", "/src/assets/fonts/OpenSans/opensansBoldItalic", bold, italic);

--- a/src/js/components/Example.vue
+++ b/src/js/components/Example.vue
@@ -1,7 +1,7 @@
 <template>
   <section>
     <div class="container">
-      <img src="/assets/img/logo.png" :alt="message" />
+      <img src="assets/img/logo.png" :alt="message" />
       <p>{{ message }}</p>
     </div>
   </section>


### PR DESCRIPTION
1. Duplicate the fonts in the dist folder and in 'assets/fonts' (now only 'assets/fonts').
2. Paths to files in dev and build assemblies are unraveled (together without editing webpack.config.js did not work).
3. Fixed popping '.svg' fonts in the folder with pictures.